### PR TITLE
Decode Query Params. [Fix #4]

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ When you simply want to display the total number of some model's database record
 
 ![Total Records](./screenshot.png)
 
-
 ## Installation
 
 You can install the package in to a Laravel app that uses [Nova](https://nova.laravel.com) via composer:
@@ -45,14 +44,14 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
             return [
                 /**
                   * PARAMETERS:
-                  * 
+                  *
                   * @param string             $model   required - the model you want to get the total count of
                   * @param string             $title   optional - the label you want to display in the Nova Card before the model count
                   * @param \DateTimeInterface $expires optional - the cache expiry time
                   */
-                new TotalRecords(App\User::class),                                            // minimum required parameters
-                new TotalRecords(App\Event::class, __('Total events')),                       // with custom label
-                new TotalRecords(App\Contact::class, __('Total contacts'), now()->addHour()), // cached for 1 hour
+                new TotalRecords(\App\User::class),                                            // minimum required parameters
+                new TotalRecords(\App\Event::class, __('Total events')),                       // with custom label
+                new TotalRecords(\App\Contact::class, __('Total contacts'), now()->addHour()), // cached for 1 hour
             ];
         }
 }

--- a/src/TotalRecordsController.php
+++ b/src/TotalRecordsController.php
@@ -19,7 +19,8 @@ class TotalRecordsController extends Controller
         $this->validate($request, ['model'   => ['bail', 'required', 'min:1', 'string', new ClassExists, new IsSubclassOfModel],
                                    'expires' => ['nullable', 'date', 'date_format:Y-m-d\TH:i:sP']]);
 
-        $model = $request->input('model');
+        // URL Decode the Model Path: https://github.com/techouse/total-records/issues/4#issuecomment-476668876
+        $model = urldecode($request->input('model'));
 
         $cacheKey = hash('md4', $model . (int)(bool)$request->input('expires'));
 


### PR DESCRIPTION
I had the same issue as #4 as the `model` string in the query parameter was getting escaped. Just had to `urldecode` it.